### PR TITLE
properly link files

### DIFF
--- a/blueprints/api-model/index.js
+++ b/blueprints/api-model/index.js
@@ -40,9 +40,16 @@ module.exports = {
       return;
     }
     const capitalCamelizedModuleName = capitalize(camelize(options.entity.name));
+<<<<<<< Updated upstream
     const content = `<!-- include(api-models/${options.entity.name}.apib) -->`;
     const groupContent = `# Group ${capitalCamelizedModuleName} ${EOL}<!-- include(api-groups/${options.entity.name}/${options.entity.name}.apib) --> ${EOL}`;
 
+=======
+    const dasherizedModuleName = dasherize(options.entity.name);
+    const content = `<!-- include(api-models/${dasherizedModuleName}.apib) -->`;
+    const groupContent = `# Group ${capitalCamelizedModuleName} ${EOL}<!-- include(api-groups/${dasherizedModuleName}/${dasherizedModuleName}.apib) --> ${EOL}`;
+    
+>>>>>>> Stashed changes
     return this.insertIntoFile(mainFile, EOL + this.sectionTitle)
       .then(() => {
         return this.insertIntoFile(mainFile, content, {
@@ -63,9 +70,16 @@ module.exports = {
     }
 
     const capitalCamelizedModuleName = capitalize(camelize(options.entity.name));
+<<<<<<< Updated upstream
     const content = `<!-- include(api-models/${options.entity.name}.apib) -->`
     const groupContent = `# Group ${capitalCamelizedModuleName} ${EOL}<!-- include(api-groups/${options.entity.name}/${options.entity.name}.apib) --> ${EOL}`;
 
+=======
+    const dasherizedModuleName = dasherize(options.entity.name);
+    const content = `<!-- include(api-models/${dasherizedModuleName}.apib) -->`
+    const groupContent = `# Group ${capitalCamelizedModuleName} ${EOL}<!-- include(api-groups/${dasherizedModuleName}/${dasherizedModuleName}.apib) --> ${EOL}`;
+    
+>>>>>>> Stashed changes
     return removeFromFile(mainFile, content)
       .then(() => removeFromFile(mainFile, groupContent) )
       .then((resultValue)=>{


### PR DESCRIPTION
fix a syntax error when creating a new api-model with a composed name. `.apib` files where not linked properly.